### PR TITLE
deprecate hiera_* functions and use lookup for merging

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,9 +3,9 @@ class resource_tree (
   $apply          = [],
   $default_params = {},
 ) {
-  $allcollections = hiera_hash('resource_tree::collections', $collections)
-  $allapply = hiera_array('resource_tree::apply', $apply)
-  $defaults = hiera_hash('resource_tree::default_params', $default_params)
+  $allcollections = lookup('resource_tree::collections', { 'value_type' => Hash, 'merge' => 'deep', 'default_value' => $collections })
+  $allapply = lookup('resource_tree::apply', { 'value_type' => Array[String], 'merge' => 'unique', 'default_value' => $apply })
+  $defaults = lookup('resource_tree::default_params', { 'value_type' => Hash, 'merge' => 'deep', 'default_value' => $default_params })
 
   if is_hash($allcollections) and is_array($allapply) and (size(intersection($allapply, keys($allcollections))) > 0) {
       $uniq_resources = parseyaml(template('resource_tree/main.erb'))


### PR DESCRIPTION
The hiera_* functions are getting deprecated in favour of the lookup function, and even if they still work in puppet versions < 6 they generate strange merge behaviour sometimes when using hiera 5.
Changing the functions to lookup() solves this.